### PR TITLE
Upgrade to D3 v4.3

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import BarChart from 'd3-bar'
 import Tip from '../index'
-import d3 from 'd3'
+import * as d3 from 'd3'
 
 const gen = n => {
   const data = []

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 import offset from 'document-offset'
-import d3 from 'd3'
+import * as d3 from 'd3'
 
 /**
  * Tip element.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "devDependencies": {
-    "d3": "^3.5.16",
+    "d3": "^4.3.0",
     "d3-bar": "^1.1.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev#49fec29"
   },


### PR DESCRIPTION
Example will require that `d3-bar` be [updated](https://github.com/tj/d3-bar/pull/7).